### PR TITLE
Fix issue with target and improve locking

### DIFF
--- a/src/slurm_autoscale_tfe/__init__.py
+++ b/src/slurm_autoscale_tfe/__init__.py
@@ -334,7 +334,14 @@ def main(command, set_op, hostlist):
             ) from exc
 
         try:
-            instances = get_instances_from_tfe(tfe_resources, hosts)
+            # Target existing instances only when removing nodes from the pool.
+            # On resume, Terraform must evaluate the broader module graph so newly
+            # requested instances can be created even if some requested instances
+            # already exist.
+            if command in (Commands.SUSPEND, Commands.RESUME_FAIL):
+                instances = get_instances_from_tfe(tfe_resources, hosts)
+            else:
+                instances = frozenset()
             provisioners = get_provisioners_from_tfe(tfe_resources)
         except KeyError as exc:
             raise AutoscaleException(

--- a/src/slurm_autoscale_tfe/__init__.py
+++ b/src/slurm_autoscale_tfe/__init__.py
@@ -15,13 +15,16 @@ from requests.exceptions import RequestException
 
 from .tfe import TFEClient
 
+POOL_VAR = environ.get("TFE_POOL_VAR", "pool")
+LOG_LEVEL = environ.get("AUTOSCALE_TFE_LOG_LEVEL", "INFO")
+
 logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
-    level=logging.INFO,
+    level=LOG_LEVEL,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-POOL_VAR = environ.get("TFE_POOL_VAR", "pool")
+
 
 INSTANCE_TYPES = frozenset(
     [
@@ -314,44 +317,45 @@ def main(command, set_op, hostlist):
                 ) from exc
         else:
             logging.warning(
-                'TFE pool variable is unchanged following the issue of "%s %s"',
+                '%s %s: TFE pool variable value is unchanged',
                 command.value,
                 hostlist,
             )
 
-    try:
-        tfe_resources = tfe_client.fetch_resources()
-    except RequestException as exc:
-        raise AutoscaleException(
-            f"TFE request failed while fetching resources: {exc}"
-        ) from exc
-    except (ValueError, KeyError) as exc:
-        raise AutoscaleException(
-            f"Invalid response while reading resources from Terraform cloud: {exc}"
-        ) from exc
+        try:
+            tfe_resources = tfe_client.fetch_resources()
+        except RequestException as exc:
+            raise AutoscaleException(
+                f"TFE request failed while fetching resources: {exc}"
+            ) from exc
+        except (ValueError, KeyError) as exc:
+            raise AutoscaleException(
+                f"Invalid response while reading resources from Terraform cloud: {exc}"
+            ) from exc
 
-    try:
-        instances = get_instances_from_tfe(tfe_resources, hosts)
-        provisioners = get_provisioners_from_tfe(tfe_resources)
-    except KeyError as exc:
-        raise AutoscaleException(
-            "Resource response from Terraform Cloud mismatches what's expected."
-        ) from exc
+        try:
+            instances = get_instances_from_tfe(tfe_resources, hosts)
+            provisioners = get_provisioners_from_tfe(tfe_resources)
+        except KeyError as exc:
+            raise AutoscaleException(
+                "Resource response from Terraform Cloud mismatches what's expected."
+            ) from exc
 
-    try:
-        run_id = tfe_client.apply(
-            f"Slurm {command.value} {hostlist}".strip(),
-            targets=list(instances | provisioners),
-        )
-    except RequestException as exc:
-        raise AutoscaleException(
-            f"TFE request failed while submitting the run: {exc}"
-        ) from exc
-    except (ValueError, KeyError) as exc:
-        raise AutoscaleException(
-            f"Invalid response while submitting the run to Terraform cloud {exc}"
-        ) from exc
-    logging.info("%s %s (%s)", command.value, hostlist, run_id)
+        try:
+            run_id = tfe_client.apply(
+                f"Slurm {command.value} {hostlist}".strip(),
+                targets=list(instances | provisioners),
+                variables=[{"key" : POOL_VAR, "value": json.dumps(list(next_pool))}]
+            )
+        except RequestException as exc:
+            raise AutoscaleException(
+                f"TFE request failed while submitting the run: {exc}"
+            ) from exc
+        except (ValueError, KeyError) as exc:
+            raise AutoscaleException(
+                f"Invalid response while submitting the run to Terraform cloud {exc}"
+            ) from exc
+        logging.info("%s %s (%s)", command.value, hostlist, run_id)
 
     if command == Commands.RESUME_FAIL:
         change_host_state(hostlist, "IDLE")

--- a/src/slurm_autoscale_tfe/tfe.py
+++ b/src/slurm_autoscale_tfe/tfe.py
@@ -148,7 +148,7 @@ class TFEClient:
         resp = self.patch(url, json=patch_data)
         return resp
 
-    def apply(self, message, targets):
+    def apply(self, message, targets, variables):
         """Queue a workspace run"""
         run_data = {
             "data": {
@@ -157,6 +157,7 @@ class TFEClient:
                     "message": message,
                     "target-addrs": targets,
                     "auto-apply": True,
+                    "variables": variables,
                 },
                 "relationships": {
                     "workspace": {"data": {"type": "workspaces", "id": self.workspace}},


### PR DESCRIPTION
When powering on a set of host, if one of the hosts was already powered on, slurm-autoscale-tfe would include it in the list of terraform target. This would then prevent other powered off instances to be powered on, because they would not be among the target.

Example:
```
2026-06-03 11:57:40 INFO resume gpupool1 (run-386GM9uEyvkyNa3v)
2026-06-03 12:00:04 INFO resume cpupool[2-10],gpupool[1-6] (run-7XGrzcFHFj17KcJY)
```

The second resume would result in an empty run in Terraform Cloud.

The solution is to only target instances when removing nodes from the pool (SUSPEND/RESUME_FAIL).

We initially suspected the Terraform variable `pool` was incorrectly synced, so we improved the overall lock mechanism to include very step of the script and not only the update of the variable. This makes sure the run submitted corresponds to the title.